### PR TITLE
Interactive chart highlighting support

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -227,7 +227,26 @@
       {"QueueID":"E771CB51-E00E-EF4E-BE95-0E2ED1B4D6E4","AssignedTo":"","Status":"","Priority":"","Payor Name":"Self Pay/Private Pay Monthly","Patient":"Nas_6917","QueueDate":"11/22/2021 - 11/26/2021"},
       {"QueueID":"1C2993B8-ACEE-2846-84AE-0F30D838BD49","AssignedTo":"Lisa Mangubat","Status":"Waiting on Agency response","Priority":"Low","Payor Name":"Medicare PPS","Patient":"Has_7010","QueueDate":"9/22/2023 4:13:24 PM"}
     ];
-    let currentFilter = {};
+    // Load persisted selections for highlights
+    let selections = JSON.parse(localStorage.getItem('chartSelections') || '{}');
+    const baseDataStore = {};
+
+    function saveSelections() {
+      localStorage.setItem('chartSelections', JSON.stringify(selections));
+    }
+
+    function toggleSelection(field, label) {
+      if(!selections[field]) selections[field] = [];
+      const idx = selections[field].indexOf(label);
+      if(idx >= 0) {
+        selections[field].splice(idx, 1);
+        if(selections[field].length === 0) delete selections[field];
+      } else {
+        selections[field].push(label);
+      }
+      saveSelections();
+      filterCharts();
+    }
 
     function assignedToData(data) {
       let count = {};
@@ -290,30 +309,51 @@
     }
     function filterData() {
       let data = rawData;
-      Object.entries(currentFilter).forEach(([field, value]) => {
-        if(value !== null) {
-          data = data.filter(d => (d[field] ? d[field] : (field === "AssignedTo" ? "" : (field === "Status" ? "" : (field === "Priority" ? "" : "")))) === value);
+      Object.entries(selections).forEach(([field, values]) => {
+        if(Array.isArray(values) && values.length) {
+          data = data.filter(d => {
+            const val = d[field] ? d[field] : "";
+            return values.includes(val);
+          });
         }
       });
       return data;
     }
-    function updateAllCharts() {
+
+    function applyBarColors(chart, field) {
+      const baseColor = 'rgba(0, 123, 255, 0.6)';
+      chart.data.datasets[0].backgroundColor = chart.data.labels.map(lbl =>
+        selections[field] && selections[field].includes(lbl) ? 'rgba(0,123,255,0.9)' : baseColor
+      );
+    }
+
+    function filterCharts() {
       let data = filterData();
       let aData = assignedToData(data);
-      assignedToChart.data.labels = aData.labels;
-      assignedToChart.data.datasets[0].data = aData.values;
+      baseDataStore['AssignedTo'] = baseDataStore['AssignedTo'] || assignedToData(rawData);
+      assignedToChart.data.labels = baseDataStore['AssignedTo'].labels;
+      assignedToChart.data.datasets[0].data = baseDataStore['AssignedTo'].values;
+      assignedToChart.data.datasets[1].data = aData.values;
+      applyBarColors(assignedToChart, 'AssignedTo');
       assignedToChart.update();
       let sData = statusData(data);
-      statusChart.data.labels = sData.labels;
-      statusChart.data.datasets[0].data = sData.values;
+      baseDataStore['Status'] = baseDataStore['Status'] || statusData(rawData);
+      statusChart.data.labels = baseDataStore['Status'].labels;
+      statusChart.data.datasets[0].data = baseDataStore['Status'].values;
+      statusChart.data.datasets[1].data = sData.values;
       statusChart.update();
       let pData = priorityData(data);
-      priorityChart.data.labels = pData.labels;
-      priorityChart.data.datasets[0].data = pData.values;
+      baseDataStore['Priority'] = baseDataStore['Priority'] || priorityData(rawData);
+      priorityChart.data.labels = baseDataStore['Priority'].labels;
+      priorityChart.data.datasets[0].data = baseDataStore['Priority'].values;
+      priorityChart.data.datasets[1].data = pData.values;
+      applyBarColors(priorityChart, 'Priority');
       priorityChart.update();
       let payData = payorData(data);
-      payorChart.data.labels = payData.labels;
-      payorChart.data.datasets[0].data = payData.values;
+      baseDataStore['Payor Name'] = baseDataStore['Payor Name'] || payorData(rawData);
+      payorChart.data.labels = baseDataStore['Payor Name'].labels;
+      payorChart.data.datasets[0].data = baseDataStore['Payor Name'].values;
+      payorChart.data.datasets[1].data = payData.values;
       payorChart.update();
       renderTable(data);
     }
@@ -325,21 +365,25 @@
         type: 'bar',
         data: {
           labels: aData.labels,
-          datasets: [{
-            label: '# Claims',
-            data: aData.values,
-            backgroundColor: 'rgba(0, 123, 255, 0.6)'
-          }]
+          datasets: [
+            {
+              label: '# Claims',
+              data: aData.values,
+              backgroundColor: aData.labels.map(() => 'rgba(0, 123, 255, 0.6)')
+            },
+            {
+              label: 'Selected',
+              data: aData.labels.map(() => 0),
+              backgroundColor: 'rgba(255,99,132,0.6)'
+            }
+          ]
         },
         options: {
           onClick: function(e, items) {
             if(items.length) {
               const label = this.data.labels[items[0].index];
-              currentFilter = { AssignedTo: label === "(Unassigned)" ? "" : label };
-            } else {
-              currentFilter = {};
+              toggleSelection('AssignedTo', label);
             }
-            updateAllCharts();
           },
           plugins: {
             legend: { display: false }
@@ -354,23 +398,27 @@
         type: 'doughnut',
         data: {
           labels: sData.labels,
-          datasets: [{
-            label: '# Claims',
-            data: sData.values,
-            backgroundColor: [
-              '#0d6efd', '#6c757d', '#198754', '#ffc107', '#dc3545', '#adb5bd'
-            ]
-          }]
+          datasets: [
+            {
+              label: '# Claims',
+              data: sData.values,
+              backgroundColor: [
+                '#0d6efd', '#6c757d', '#198754', '#ffc107', '#dc3545', '#adb5bd'
+              ]
+            },
+            {
+              label: 'Selected',
+              data: sData.labels.map(() => 0),
+              backgroundColor: 'rgba(255,99,132,0.6)'
+            }
+          ]
         },
         options: {
           onClick: function(e, items) {
             if(items.length) {
               const label = this.data.labels[items[0].index];
-              currentFilter = { Status: label === "(No Status)" ? "" : label };
-            } else {
-              currentFilter = {};
+              toggleSelection('Status', label);
             }
-            updateAllCharts();
           },
           plugins: { legend: { position: 'bottom' } },
           cutout: "65%"
@@ -382,21 +430,25 @@
         type: 'bar',
         data: {
           labels: pData.labels,
-          datasets: [{
-            label: '# Claims',
-            data: pData.values,
-            backgroundColor: 'rgba(253, 126, 20, 0.7)'
-          }]
+          datasets: [
+            {
+              label: '# Claims',
+              data: pData.values,
+              backgroundColor: pData.labels.map(() => 'rgba(253, 126, 20, 0.7)')
+            },
+            {
+              label: 'Selected',
+              data: pData.labels.map(() => 0),
+              backgroundColor: 'rgba(255,99,132,0.6)'
+            }
+          ]
         },
         options: {
           onClick: function(e, items) {
             if(items.length) {
               const label = this.data.labels[items[0].index];
-              currentFilter = { Priority: label === "(None)" ? "" : label };
-            } else {
-              currentFilter = {};
+              toggleSelection('Priority', label);
             }
-            updateAllCharts();
           },
           plugins: {
             legend: { display: false }
@@ -411,29 +463,33 @@
         type: 'pie',
         data: {
           labels: payData.labels,
-          datasets: [{
-            label: '# Claims',
-            data: payData.values,
-            backgroundColor: [
-              '#007bff','#6610f2','#6f42c1','#d63384','#fd7e14','#ffc107','#28a745','#20c997'
-            ]
-          }]
+          datasets: [
+            {
+              label: '# Claims',
+              data: payData.values,
+              backgroundColor: [
+                '#007bff','#6610f2','#6f42c1','#d63384','#fd7e14','#ffc107','#28a745','#20c997'
+              ]
+            },
+            {
+              label: 'Selected',
+              data: payData.labels.map(() => 0),
+              backgroundColor: 'rgba(255,99,132,0.6)'
+            }
+          ]
         },
         options: {
           onClick: function(e, items) {
             if(items.length) {
               const label = this.data.labels[items[0].index];
-              currentFilter = { "Payor Name": label === "(Unknown)" ? "" : label };
-            } else {
-              currentFilter = {};
+              toggleSelection('Payor Name', label);
             }
-            updateAllCharts();
           },
           plugins: { legend: { position: 'bottom' } }
         }
       });
 
-      renderTable(rawData);
+      filterCharts();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add highlight dataset logic and helpers
- update charts to color based on selections
- store selections in `localStorage`

## Testing
- `node -e "require('fs').readFileSync('QueueManagerDashboardTemplate.html','utf8'); console.log('loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_688a7b5ff6d4832cb92d455032e38531