### PR TITLE
Fix feather icons rendering

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -531,6 +531,7 @@
         highPriorityChart, overdueChart, parentUnitChart,
         dueDateTrendChart, dueDateThisWeekChart, queueAgingChart;
     $(function() {
+      feather.replace();
       let aData = assignedToData(rawData);
       assignedToChart = new Chart($("#assignedToChart"), {
         type: 'bar',


### PR DESCRIPTION
## Summary
- ensure Feather icons render correctly by calling `feather.replace()` on page load

## Testing
- `grep -n "feather.replace" -n QueueManagerDashboardTemplate.html`

------
https://chatgpt.com/codex/tasks/task_e_688ad377cac0832c87329dd2575b5255