### PR TITLE
Add DataTables and zoom controls to dashboard

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -7,6 +7,13 @@
   <script src="https://unpkg.com/feather-icons"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.dataTables.min.css">
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.colVis.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <style>
     body { margin: 0; font-family: Arial, sans-serif; display: flex; height: 100vh; }
     .sidebar {
@@ -106,6 +113,18 @@
       color: #007bff;
       font-weight: 500;
     }
+    .zoom-controls {
+      display: inline-flex;
+      margin-left: 10px;
+    }
+    .zoom-controls button {
+      background: none;
+      border: 1px solid #ccc;
+      margin-left: 4px;
+      cursor: pointer;
+      padding: 4px;
+      border-radius: 4px;
+    }
     .right-panel-toggle {
       position: fixed;
       top: 50%;
@@ -159,6 +178,10 @@
   <div class="main-content">
     <div id="dashboard">
       <div class="dashboard-title">RCM Queue Dashboard</div>
+      <div class="zoom-controls">
+        <button onclick="zoomIn()"><i data-feather="zoom-in"></i></button>
+        <button onclick="zoomOut()"><i data-feather="zoom-out"></i></button>
+      </div>
       <div class="charts-grid">
         <div class="chart-card">
           <div class="chart-title">Assigned To Distribution</div>
@@ -248,6 +271,21 @@
     function toggleRightPanel() {
       const panel = document.getElementById('rightPanel');
       panel.classList.toggle('open');
+    }
+
+    let zoomLevel = 1;
+    function applyZoom() {
+      const dash = document.getElementById('dashboard');
+      dash.style.transform = `scale(${zoomLevel})`;
+      dash.style.transformOrigin = '0 0';
+    }
+    function zoomIn() {
+      zoomLevel = Math.min(2, zoomLevel + 0.1);
+      applyZoom();
+    }
+    function zoomOut() {
+      zoomLevel = Math.max(0.5, zoomLevel - 0.1);
+      applyZoom();
     }
 
     // ---- SAMPLE DATA (Replace with your actual JSON!) ----
@@ -430,24 +468,26 @@
       return `${year}-W${week}`;
     }
     function renderTable(data) {
-      let rows = "";
-      data.forEach(d => {
-        rows += `<tr>
-          <td>${d.QueueID}</td>
-          <td>${d.Patient || ""}</td>
-          <td>${d["Payor Name"] || ""}</td>
-          <td>${d["Parent Unit"] || ""}</td>
-          <td>${d.Priority || ""}</td>
-          <td>${d.Status || ""}</td>
-          <td>${d.RFNP || ""}</td>
-          <td>${d.subRFNP || ""}</td>
-          <td>${d.AssignedTo || ""}</td>
-          <td>${d.Admin || ""}</td>
-          <td>${d.DueDate || ""}</td>
-          <td>${d["Event Date"] || ""}</td>
-        </tr>`;
-      });
-      $("#tableBody").html(rows);
+      const rows = data.map(d => [
+        d.QueueID,
+        d.Patient || "",
+        d["Payor Name"] || "",
+        d["Parent Unit"] || "",
+        d.Priority || "",
+        d.Status || "",
+        d.RFNP || "",
+        d.subRFNP || "",
+        d.AssignedTo || "",
+        d.Admin || "",
+        d.DueDate || "",
+        d["Event Date"] || ""
+      ]);
+      if (table) {
+        table.clear().rows.add(rows).draw();
+      } else {
+        let html = rows.map(r => `<tr>${r.map(c => `<td>${c}</td>`).join('')}</tr>`).join('');
+        $("#tableBody").html(html);
+      }
     }
     function filterData() {
       let data = rawData;
@@ -543,7 +583,8 @@
 
     let assignedToChart, statusChart, priorityChart, payorChart,
         highPriorityChart, overdueChart, parentUnitChart,
-        dueDateTrendChart, dueDateThisWeekChart, queueAgingChart;
+        dueDateTrendChart, dueDateThisWeekChart, queueAgingChart,
+        table;
     $(function() {
       feather.replace();
       let aData = assignedToData(rawData);
@@ -830,6 +871,21 @@
       });
 
       renderTable(rawData);
+      table = $('#data-table table').DataTable({
+        scrollX: true,
+        scrollY: '400px',
+        paging: true,
+        ordering: true,
+        lengthMenu: [10, 25, 50, 100],
+        dom: 'Bfrtip',
+        buttons: [
+          { extend: 'excel', text: feather.icons['download'].toSvg() },
+          { extend: 'csv', text: feather.icons['file-text'].toSvg() },
+          'colvis'
+        ]
+      });
+      feather.replace();
+      applyZoom();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- integrate DataTables and Buttons extension
- add zoom in/out UI with accompanying styles and scripts
- update table rendering function to cooperate with DataTables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ad62fa338832c9e883c973e849f18