### PR TITLE
Integrate zoom controls into DataTables

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -113,18 +113,6 @@
       color: #007bff;
       font-weight: 500;
     }
-    .zoom-controls {
-      display: inline-flex;
-      margin-left: 10px;
-    }
-    .zoom-controls button {
-      background: none;
-      border: 1px solid #ccc;
-      margin-left: 4px;
-      cursor: pointer;
-      padding: 4px;
-      border-radius: 4px;
-    }
     .right-panel-toggle {
       position: fixed;
       top: 50%;
@@ -178,10 +166,6 @@
   <div class="main-content">
     <div id="dashboard">
       <div class="dashboard-title">RCM Queue Dashboard</div>
-      <div class="zoom-controls">
-        <button onclick="zoomIn()"><i data-feather="zoom-in"></i></button>
-        <button onclick="zoomOut()"><i data-feather="zoom-out"></i></button>
-      </div>
       <div class="charts-grid">
         <div class="chart-card">
           <div class="chart-title">Assigned To Distribution</div>
@@ -275,7 +259,7 @@
 
     let zoomLevel = 1;
     function applyZoom() {
-      const dash = document.getElementById('dashboard');
+      const dash = document.getElementById('data-table');
       dash.style.transform = `scale(${zoomLevel})`;
       dash.style.transformOrigin = '0 0';
     }
@@ -879,8 +863,10 @@
         lengthMenu: [10, 25, 50, 100],
         dom: 'Bfrtip',
         buttons: [
-          { extend: 'excel', text: feather.icons['download'].toSvg() },
-          { extend: 'csv', text: feather.icons['file-text'].toSvg() },
+          { extend: 'excel', text: feather.icons["download"].toSvg() },
+          { extend: 'csv', text: feather.icons["file-text"].toSvg() },
+          { text: feather.icons["zoom-in"].toSvg(), action: function(){ zoomIn(); } },
+          { text: feather.icons["zoom-out"].toSvg(), action: function(){ zoomOut(); } },
           'colvis'
         ]
       });


### PR DESCRIPTION
## Summary
- remove old zoom-controls markup and styles
- reintroduce DataTables setup with built-in zoom buttons
- scale the data table container instead of the dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688adf085ea4832c91df86a935468dad