### PR TITLE
Remove colvis button from DataTables

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -866,8 +866,7 @@
           { extend: 'excel', text: feather.icons["download"].toSvg() },
           { extend: 'csv', text: feather.icons["file-text"].toSvg() },
           { text: feather.icons["zoom-in"].toSvg(), action: function(){ zoomIn(); } },
-          { text: feather.icons["zoom-out"].toSvg(), action: function(){ zoomOut(); } },
-          'colvis'
+          { text: feather.icons["zoom-out"].toSvg(), action: function(){ zoomOut(); } }
         ]
       });
       feather.replace();


### PR DESCRIPTION
## Summary
- remove the `colvis` button from DataTables setup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688ae0a10a04832c99650ac85696aea0