### PR TITLE
Add page length selector to DataTables

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -869,6 +869,17 @@
           { text: feather.icons["zoom-out"].toSvg(), action: function(){ zoomOut(); } }
         ]
       });
+
+      // Add page length selector next to the export buttons
+      const pageLength = $('<select id="pageLength"></select>');
+      table.settings().init().lengthMenu.forEach(len => {
+        pageLength.append(`<option value="${len}">${len}</option>`);
+      });
+      $('.dt-buttons').append(pageLength);
+      $('#pageLength').on('change', function() {
+        table.page.len(parseInt($(this).val())).draw();
+      });
+
       feather.replace();
       applyZoom();
     });


### PR DESCRIPTION
## Summary
- add a `#pageLength` selector next to export buttons
- hook selector up to `page.len()` so users can change rows displayed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688ae1a7d680832ca5a1822505ce8dc1