### PR TITLE
Add UB04 & Correspondence dashboard chart

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -258,9 +258,9 @@
           <canvas id="queueAgingChart"></canvas>
         </div>
 
-        <div class="chart-card" title="Similar to ‘Claims by Parent Unit,’ this reinforces visibility at the organizational unit level. Ensures redundancy and quick access to unit-based breakdowns.">
-          <div class="chart-title">Parent Unit Distribution</div>
-          <canvas id="parentUnitDistChart"></canvas>
+        <div class="chart-card" title="Counts claims with UB04 or Correspondence flags for quick tracking of documentation statuses.">
+          <div class="chart-title">UB04 &amp; Correspondence</div>
+          <canvas id="ub04CorrespondenceChart"></canvas>
         </div>
 
           <div class="chart-card" title="Tracks documentation of outreach or follow-up actions associated with a queue. A high volume may indicate escalated or complex cases, and it can help monitor communication efficiency.">
@@ -537,6 +537,19 @@
       };
     }
 
+    function ub04CorrespondenceData(data) {
+      let ub04Count = 0;
+      let corrCount = 0;
+      data.forEach(d => {
+        if (d["UB04"]) ub04Count++;
+        if (d["Correspondence"]) corrCount++;
+      });
+      return {
+        labels: ["UB04", "Correspondence"],
+        values: [ub04Count, corrCount]
+      };
+    }
+
     function rfnpData(data) {
       let count = {};
       data.forEach(d => {
@@ -771,30 +784,36 @@
       setChartColors(subRfnpChart, 'subRFNP');
       subRfnpChart.update();
 
-      let puDistData = parentUnitData(data);
-      parentUnitDistChart.data.labels = puDistData.labels;
-      parentUnitDistChart.data.datasets[0].data = puDistData.values;
-      setChartColors(parentUnitDistChart, 'Parent Unit');
-        parentUnitDistChart.update();
+      let ubData = ub04CorrespondenceData(data);
+      ub04CorrespondenceChart.data.labels = ubData.labels;
+      ub04CorrespondenceChart.data.datasets[0].data = ubData.values;
+      setChartColors(
+        ub04CorrespondenceChart,
+        null,
+        (lbl) =>
+          (lbl === "UB04" && currentFilter.UB04 === "1") ||
+          (lbl === "Correspondence" && currentFilter.Correspondence === "1")
+      );
+      ub04CorrespondenceChart.update();
 
-        let adData = adminData(data);
-        adminChart.data.labels = adData.labels;
-        adminChart.data.datasets[0].data = adData.values;
-        setChartColors(adminChart, 'Admin');
-        adminChart.update();
+      let adData = adminData(data);
+      adminChart.data.labels = adData.labels;
+      adminChart.data.datasets[0].data = adData.values;
+      setChartColors(adminChart, 'Admin');
+      adminChart.update();
 
-        let clData = callLogData(data);
-        callLogChart.data.labels = clData.labels;
-        callLogChart.data.datasets[0].data = clData.values;
-        setChartColors(callLogChart, 'Call Log');
-        callLogChart.update();
-        renderTable(data);
-      }
+      let clData = callLogData(data);
+      callLogChart.data.labels = clData.labels;
+      callLogChart.data.datasets[0].data = clData.values;
+      setChartColors(callLogChart, 'Call Log');
+      callLogChart.update();
+      renderTable(data);
+    }
 
       let assignedToChart, statusChart, priorityChart, payorChart,
           highPriorityChart, overdueChart, parentUnitChart,
           dueDateTrendChart, dueDateThisWeekChart, queueAgingChart,
-          rfnpChart, subRfnpChart, parentUnitDistChart, adminChart,
+          rfnpChart, subRfnpChart, ub04CorrespondenceChart, adminChart,
           callLogChart,
           table;
     $(function() {
@@ -1137,22 +1156,29 @@
       });
       subRfnpChart.data.datasets[0].baseColor = 'rgba(111, 66, 193, 0.6)';
 
-      let puDistData = parentUnitData(rawData);
-      parentUnitDistChart = new Chart($("#parentUnitDistChart"), {
+      let ubData = ub04CorrespondenceData(rawData);
+      ub04CorrespondenceChart = new Chart($("#ub04CorrespondenceChart"), {
         type: 'bar',
         data: {
-          labels: puDistData.labels,
+          labels: ubData.labels,
           datasets: [{
             label: '# Claims',
-            data: puDistData.values,
-            backgroundColor: 'rgba(40, 167, 69, 0.6)'
+            data: ubData.values,
+            backgroundColor: [
+              'rgba(40, 167, 69, 0.6)',
+              'rgba(0, 123, 255, 0.6)'
+            ]
           }]
         },
         options: {
           onClick: function(e, items) {
             if(items.length) {
               const label = this.data.labels[items[0].index];
-              toggleFilter('Parent Unit', label === "(Unknown)" ? "" : label);
+              if(label === "UB04") {
+                toggleFilter('UB04', '1');
+              } else if(label === "Correspondence") {
+                toggleFilter('Correspondence', '1');
+              }
             }
             updateAllCharts();
           },
@@ -1162,7 +1188,10 @@
           scales: { x: { beginAtZero: true } }
         }
       });
-      parentUnitDistChart.data.datasets[0].baseColor = 'rgba(40, 167, 69, 0.6)';
+      ub04CorrespondenceChart.data.datasets[0].baseColor = [
+        'rgba(40, 167, 69, 0.6)',
+        'rgba(0, 123, 255, 0.6)'
+      ];
 
       let adData = adminData(rawData);
       adminChart = new Chart($("#adminChart"), {


### PR DESCRIPTION
## Summary
- Replace Parent Unit Distribution card with UB04 & Correspondence chart
- Add `ub04CorrespondenceData` and integrate new chart into dashboard refresh
- Initialize bar chart with filter toggles for UB04 and Correspondence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68961a06e9f0832c9131b3970022725a