### PR TITLE
Organize dashboard charts with collapsible sections

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -199,70 +199,86 @@
     <div id="dashboard">
       <div class="dashboard-title">RCM Queue Dashboard</div>
       <button id="clearFilters" onclick="clearAllFilters()" style="margin-bottom:10px;">Clear All Filters</button>
-      <div class="charts-grid">
-        <div class="chart-card" title="Visualizes the distribution of queues across different care units (e.g., Home Health, Hospice). Helps identify where queue volume is concentrated at the organizational level.">
-          <div class="chart-title">Queues by Parent Unit</div>
-          <canvas id="parentUnitChart"></canvas>
+      <details open>
+        <summary>Queue Overview</summary>
+        <div class="charts-grid">
+          <div class="chart-card" title="Visualizes the distribution of queues across different care units (e.g., Home Health, Hospice). Helps identify where queue volume is concentrated at the organizational level.">
+            <div class="chart-title">Queues by Parent Unit</div>
+            <canvas id="parentUnitChart"></canvas>
+          </div>
+          <div class="chart-card" title="Shows the current processing status of Queues (e.g., Billed, Denied, RFNP). Useful for quickly understanding bottlenecks and queue stages.">
+            <div class="chart-title">Status Breakdown</div>
+            <canvas id="statusChart"></canvas>
+          </div>
+          <div class="chart-card" title="Displays Queue counts segmented by priority levels (e.g., Low, Medium, High). Useful for assessing urgency and workload severity across the team.">
+            <div class="chart-title">Priority Trend</div>
+            <canvas id="priorityChart"></canvas>
+          </div>
+          <div class="chart-card" title="Breaks down volume by insurance payor (e.g., Medicare PPS, Kaiser, UHC). Useful for identifying key payors and monitoring high-volume relationships.">
+            <div class="chart-title">Queues by Payor</div>
+            <canvas id="payorChart"></canvas>
+          </div>
+          <div class="chart-card" title="Categorizes Queues by how long they’ve been in the queue, based on the number of days since QueueDate. Supports aging reports and time-to-resolution improvement.">
+            <div class="chart-title">Queue Aging</div>
+            <canvas id="queueAgingChart"></canvas>
+          </div>
+          <div class="chart-card" title="Highlights why Queues were returned or unpaid. Essential for RCM teams to spot recurring issues and reduce denials.">
+            <div class="chart-title">RFNP Breakdown</div>
+            <canvas id="rfnpChart"></canvas>
+          </div>
+          <div class="chart-card" title="Provides deeper insight into subcategories of non-payment causes. Helps prioritize training, process fixes, or payor escalation strategies.">
+            <div class="chart-title">subRFNP Breakdown</div>
+            <canvas id="subRfnpChart"></canvas>
+          </div>
         </div>
-        <div class="chart-card" title="Tracks how queues are distributed across individual billers. Useful for managing productivity and ensuring balanced workload for team members actively resolving queues.">
-          <div class="chart-title">Assigned To Distribution</div>
-          <canvas id="assignedToChart"></canvas>
-        </div>
-                  <div class="chart-card" title="Reflects ownership of queues at the admin level. If a queue is assigned to an Admin, they are expected to be the primary driver of resolution, while the AssignedTo (biller) acts in a supporting role.">
+      </details>
+
+      <details>
+        <summary>Performance</summary>
+        <div class="charts-grid">
+          <div class="chart-card" title="Tracks how queues are distributed across individual billers. Useful for managing productivity and ensuring balanced workload for team members actively resolving queues.">
+            <div class="chart-title">Assigned To Distribution</div>
+            <canvas id="assignedToChart"></canvas>
+          </div>
+          <div class="chart-card" title="Reflects ownership of queues at the admin level. If a queue is assigned to an Admin, they are expected to be the primary driver of resolution, while the AssignedTo (biller) acts in a supporting role.">
             <div class="chart-title">Admin Distribution</div>
             <canvas id="adminChart"></canvas>
           </div>
-          
-        <div class="chart-card" title="Shows the current processing status of Queues (e.g., Billed, Denied, RFNP). Useful for quickly understanding bottlenecks and queue stages.">
-          <div class="chart-title">Status Breakdown</div>
-          <canvas id="statusChart"></canvas>
+          <div class="chart-card" title="Isolates and visualizes Queues marked as ‘High’ priority. Allows quick intervention in time-sensitive cases. Also represented numerically in #highPriorityCount.">
+            <div class="chart-title">High Priority Queues</div>
+            <canvas id="highPriorityChart"></canvas>
+          </div>
+          <div class="chart-card" title="Flags Queues where DueDate < Today. Indicates missed timelines and potential revenue delays. Also summarized in #overdueCount.">
+            <div class="chart-title">Overdue Queues</div>
+            <canvas id="overdueChart"></canvas>
+          </div>
+          <div class="chart-card" title="Displays weekly trends in upcoming Queue due dates. Useful for forecasting workload and aligning team capacity to demand.">
+            <div class="chart-title">Due Date Trend</div>
+            <canvas id="dueDateTrendChart"></canvas>
+          </div>
+          <div class="chart-card" title="Segments Queues due in the current calendar week by weekday. Helps prioritize daily workflow for short-term execution.">
+            <div class="chart-title">Queues Due This Week</div>
+            <canvas id="dueDateThisWeekChart"></canvas>
+          </div>
         </div>
+      </details>
 
-        <div class="chart-card" title="Highlights why Queues were returned or unpaid. Essential for RCM teams to spot recurring issues and reduce denials.">
-          <div class="chart-title">RFNP Breakdown</div>
-          <canvas id="rfnpChart"></canvas>
+      <details>
+        <summary>Documentation</summary>
+        <div class="charts-grid">
+          <div class="chart-card" title="Counts Queues with UB04 or Correspondence flags for quick tracking of documentation statuses.">
+            <div class="chart-title">UB04 &amp; Correspondence</div>
+            <canvas id="ub04CorrespondenceChart"></canvas>
+          </div>
         </div>
+      </details>
 
-        <div class="chart-card" title="Provides deeper insight into subcategories of non-payment causes. Helps prioritize training, process fixes, or payor escalation strategies.">
-          <div class="chart-title">subRFNP Breakdown</div>
-          <canvas id="subRfnpChart"></canvas>
+      <details>
+        <summary>Activity Logs</summary>
+        <div class="charts-grid">
+          <!-- Future LOG charts -->
         </div>
-
-        <div class="chart-card" title="Displays Queue counts segmented by priority levels (e.g., Low, Medium, High). Useful for assessing urgency and workload severity across the team.">
-          <div class="chart-title">Priority Trend</div>
-          <canvas id="priorityChart"></canvas>
-        </div>
-        <div class="chart-card" title="Breaks down volume by insurance payor (e.g., Medicare PPS, Kaiser, UHC). Useful for identifying key payors and monitoring high-volume relationships.">
-          <div class="chart-title">Queues by Payor</div>
-          <canvas id="payorChart"></canvas>
-        </div>
-        <div class="chart-card" title="Isolates and visualizes Queues marked as ‘High’ priority. Allows quick intervention in time-sensitive cases. Also represented numerically in #highPriorityCount.">
-          <div class="chart-title">High Priority Queues</div>
-          <canvas id="highPriorityChart"></canvas>
-        </div>
-        <div class="chart-card" title="Flags Queues where DueDate < Today. Indicates missed timelines and potential revenue delays. Also summarized in #overdueCount.">
-          <div class="chart-title">Overdue Queues</div>
-          <canvas id="overdueChart"></canvas>
-        </div>
-
-        <div class="chart-card" title="Displays weekly trends in upcoming Queue due dates. Useful for forecasting workload and aligning team capacity to demand.">
-          <div class="chart-title">Due Date Trend</div>
-          <canvas id="dueDateTrendChart"></canvas>
-        </div>
-        <div class="chart-card" title="Segments Queues due in the current calendar week by weekday. Helps prioritize daily workflow for short-term execution.">
-          <div class="chart-title">Queues Due This Week</div>
-          <canvas id="dueDateThisWeekChart"></canvas>
-        </div>
-        <div class="chart-card" title="Categorizes Queues by how long they’ve been in the queue, based on the number of days since QueueDate. Supports aging reports and time-to-resolution improvement.">
-          <div class="chart-title">Queue Aging</div>
-          <canvas id="queueAgingChart"></canvas>
-        </div>
-
-        <div class="chart-card" title="Counts Queues with UB04 or Correspondence flags for quick tracking of documentation statuses.">
-          <div class="chart-title">UB04 &amp; Correspondence</div>
-          <canvas id="ub04CorrespondenceChart"></canvas>
-        </div>
-      </div>
+      </details>
       <div id="data-table">
         <div class="filter-label">Details Table (Filtered):</div>
         <table>


### PR DESCRIPTION
## Summary
- Group dashboard charts into collapsible `<details>` sections for Queue Overview, Performance, Documentation, and Activity Logs
- Preserve responsive `.charts-grid` layout inside each section and redistribute charts accordingly

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/QueueManager/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6898c2b5df9c832c83c08f42fa4f184b