### PR TITLE
Add tab navigation for dashboard charts

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -179,6 +179,27 @@
       margin-left: 4px;
     }
     .call-log-btn:hover { background: #1e7e34; }
+    /* Tab navigation styles */
+    .nav-tabs {
+      border-bottom: 1px solid #dee2e6;
+      margin-bottom: 20px;
+      padding-left: 0;
+      list-style: none;
+      display: flex;
+    }
+    .nav-tabs .nav-link {
+      border: 1px solid transparent;
+      padding: 8px 12px;
+      cursor: pointer;
+      margin-right: 4px;
+    }
+    .nav-tabs .nav-link.active {
+      border: 1px solid #dee2e6;
+      border-bottom-color: #fff;
+      background: #fff;
+    }
+    .tab-pane { display: none; }
+    .tab-pane.active { display: block; }
   </style>
 </head>
 <body>
@@ -199,86 +220,100 @@
     <div id="dashboard">
       <div class="dashboard-title">RCM Queue Dashboard</div>
       <button id="clearFilters" onclick="clearAllFilters()" style="margin-bottom:10px;">Clear All Filters</button>
-      <details open>
-        <summary>Queue Overview</summary>
-        <div class="charts-grid">
-          <div class="chart-card" title="Visualizes the distribution of queues across different care units (e.g., Home Health, Hospice). Helps identify where queue volume is concentrated at the organizational level.">
-            <div class="chart-title">Queues by Parent Unit</div>
-            <canvas id="parentUnitChart"></canvas>
-          </div>
-          <div class="chart-card" title="Shows the current processing status of Queues (e.g., Billed, Denied, RFNP). Useful for quickly understanding bottlenecks and queue stages.">
-            <div class="chart-title">Status Breakdown</div>
-            <canvas id="statusChart"></canvas>
-          </div>
-          <div class="chart-card" title="Displays Queue counts segmented by priority levels (e.g., Low, Medium, High). Useful for assessing urgency and workload severity across the team.">
-            <div class="chart-title">Priority Trend</div>
-            <canvas id="priorityChart"></canvas>
-          </div>
-          <div class="chart-card" title="Breaks down volume by insurance payor (e.g., Medicare PPS, Kaiser, UHC). Useful for identifying key payors and monitoring high-volume relationships.">
-            <div class="chart-title">Queues by Payor</div>
-            <canvas id="payorChart"></canvas>
-          </div>
-          <div class="chart-card" title="Categorizes Queues by how long they’ve been in the queue, based on the number of days since QueueDate. Supports aging reports and time-to-resolution improvement.">
-            <div class="chart-title">Queue Aging</div>
-            <canvas id="queueAgingChart"></canvas>
-          </div>
-          <div class="chart-card" title="Highlights why Queues were returned or unpaid. Essential for RCM teams to spot recurring issues and reduce denials.">
-            <div class="chart-title">RFNP Breakdown</div>
-            <canvas id="rfnpChart"></canvas>
-          </div>
-          <div class="chart-card" title="Provides deeper insight into subcategories of non-payment causes. Helps prioritize training, process fixes, or payor escalation strategies.">
-            <div class="chart-title">subRFNP Breakdown</div>
-            <canvas id="subRfnpChart"></canvas>
-          </div>
-        </div>
-      </details>
+      <ul class="nav nav-tabs" id="dashboardTabs">
+        <li class="nav-item"><a class="nav-link active" href="#tab-overview">Overview</a></li>
+        <li class="nav-item"><a class="nav-link" href="#tab-trends">Trends</a></li>
+        <li class="nav-item"><a class="nav-link" href="#tab-activity">Activity Logs</a></li>
+      </ul>
 
-      <details>
-        <summary>Performance</summary>
-        <div class="charts-grid">
-          <div class="chart-card" title="Tracks how queues are distributed across individual billers. Useful for managing productivity and ensuring balanced workload for team members actively resolving queues.">
-            <div class="chart-title">Assigned To Distribution</div>
-            <canvas id="assignedToChart"></canvas>
-          </div>
-          <div class="chart-card" title="Reflects ownership of queues at the admin level. If a queue is assigned to an Admin, they are expected to be the primary driver of resolution, while the AssignedTo (biller) acts in a supporting role.">
-            <div class="chart-title">Admin Distribution</div>
-            <canvas id="adminChart"></canvas>
-          </div>
-          <div class="chart-card" title="Isolates and visualizes Queues marked as ‘High’ priority. Allows quick intervention in time-sensitive cases. Also represented numerically in #highPriorityCount.">
-            <div class="chart-title">High Priority Queues</div>
-            <canvas id="highPriorityChart"></canvas>
-          </div>
-          <div class="chart-card" title="Flags Queues where DueDate < Today. Indicates missed timelines and potential revenue delays. Also summarized in #overdueCount.">
-            <div class="chart-title">Overdue Queues</div>
-            <canvas id="overdueChart"></canvas>
-          </div>
-          <div class="chart-card" title="Displays weekly trends in upcoming Queue due dates. Useful for forecasting workload and aligning team capacity to demand.">
-            <div class="chart-title">Due Date Trend</div>
-            <canvas id="dueDateTrendChart"></canvas>
-          </div>
-          <div class="chart-card" title="Segments Queues due in the current calendar week by weekday. Helps prioritize daily workflow for short-term execution.">
-            <div class="chart-title">Queues Due This Week</div>
-            <canvas id="dueDateThisWeekChart"></canvas>
-          </div>
-        </div>
-      </details>
+      <div class="tab-content">
+        <div id="tab-overview" class="tab-pane active">
+          <details open>
+            <summary>Queue Overview</summary>
+            <div class="charts-grid">
+              <div class="chart-card" title="Visualizes the distribution of queues across different care units (e.g., Home Health, Hospice). Helps identify where queue volume is concentrated at the organizational level.">
+                <div class="chart-title">Queues by Parent Unit</div>
+                <canvas id="parentUnitChart"></canvas>
+              </div>
+              <div class="chart-card" title="Shows the current processing status of Queues (e.g., Billed, Denied, RFNP). Useful for quickly understanding bottlenecks and queue stages.">
+                <div class="chart-title">Status Breakdown</div>
+                <canvas id="statusChart"></canvas>
+              </div>
+              <div class="chart-card" title="Displays Queue counts segmented by priority levels (e.g., Low, Medium, High). Useful for assessing urgency and workload severity across the team.">
+                <div class="chart-title">Priority Trend</div>
+                <canvas id="priorityChart"></canvas>
+              </div>
+              <div class="chart-card" title="Breaks down volume by insurance payor (e.g., Medicare PPS, Kaiser, UHC). Useful for identifying key payors and monitoring high-volume relationships.">
+                <div class="chart-title">Queues by Payor</div>
+                <canvas id="payorChart"></canvas>
+              </div>
+              <div class="chart-card" title="Categorizes Queues by how long they’ve been in the queue, based on the number of days since QueueDate. Supports aging reports and time-to-resolution improvement.">
+                <div class="chart-title">Queue Aging</div>
+                <canvas id="queueAgingChart"></canvas>
+              </div>
+              <div class="chart-card" title="Highlights why Queues were returned or unpaid. Essential for RCM teams to spot recurring issues and reduce denials.">
+                <div class="chart-title">RFNP Breakdown</div>
+                <canvas id="rfnpChart"></canvas>
+              </div>
+              <div class="chart-card" title="Provides deeper insight into subcategories of non-payment causes. Helps prioritize training, process fixes, or payor escalation strategies.">
+                <div class="chart-title">subRFNP Breakdown</div>
+                <canvas id="subRfnpChart"></canvas>
+              </div>
+            </div>
+          </details>
 
-      <details>
-        <summary>Documentation</summary>
-        <div class="charts-grid">
-          <div class="chart-card" title="Counts Queues with UB04 or Correspondence flags for quick tracking of documentation statuses.">
-            <div class="chart-title">UB04 &amp; Correspondence</div>
-            <canvas id="ub04CorrespondenceChart"></canvas>
+          <details>
+            <summary>Performance</summary>
+            <div class="charts-grid">
+              <div class="chart-card" title="Tracks how queues are distributed across individual billers. Useful for managing productivity and ensuring balanced workload for team members actively resolving queues.">
+                <div class="chart-title">Assigned To Distribution</div>
+                <canvas id="assignedToChart"></canvas>
+              </div>
+              <div class="chart-card" title="Reflects ownership of queues at the admin level. If a queue is assigned to an Admin, they are expected to be the primary driver of resolution, while the AssignedTo (biller) acts in a supporting role.">
+                <div class="chart-title">Admin Distribution</div>
+                <canvas id="adminChart"></canvas>
+              </div>
+              <div class="chart-card" title="Isolates and visualizes Queues marked as ‘High’ priority. Allows quick intervention in time-sensitive cases. Also represented numerically in #highPriorityCount.">
+                <div class="chart-title">High Priority Queues</div>
+                <canvas id="highPriorityChart"></canvas>
+              </div>
+              <div class="chart-card" title="Flags Queues where DueDate < Today. Indicates missed timelines and potential revenue delays. Also summarized in #overdueCount.">
+                <div class="chart-title">Overdue Queues</div>
+                <canvas id="overdueChart"></canvas>
+              </div>
+            </div>
+          </details>
+
+          <details>
+            <summary>Documentation</summary>
+            <div class="charts-grid">
+              <div class="chart-card" title="Counts Queues with UB04 or Correspondence flags for quick tracking of documentation statuses.">
+                <div class="chart-title">UB04 &amp; Correspondence</div>
+                <canvas id="ub04CorrespondenceChart"></canvas>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <div id="tab-trends" class="tab-pane">
+          <div class="charts-grid">
+            <div class="chart-card" title="Displays weekly trends in upcoming Queue due dates. Useful for forecasting workload and aligning team capacity to demand.">
+              <div class="chart-title">Due Date Trend</div>
+              <canvas id="dueDateTrendChart"></canvas>
+            </div>
+            <div class="chart-card" title="Segments Queues due in the current calendar week by weekday. Helps prioritize daily workflow for short-term execution.">
+              <div class="chart-title">Queues Due This Week</div>
+              <canvas id="dueDateThisWeekChart"></canvas>
+            </div>
           </div>
         </div>
-      </details>
 
-      <details>
-        <summary>Activity Logs</summary>
-        <div class="charts-grid">
-          <!-- Future LOG charts -->
+        <div id="tab-activity" class="tab-pane">
+          <div class="charts-grid">
+            <!-- Future LOG charts -->
+          </div>
         </div>
-      </details>
+      </div>
       <div id="data-table">
         <div class="filter-label">Details Table (Filtered):</div>
         <table>
@@ -318,6 +353,19 @@
   </div>
 
   <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const tabLinks = document.querySelectorAll('#dashboardTabs .nav-link');
+      const tabPanes = document.querySelectorAll('.tab-pane');
+      tabLinks.forEach(link => {
+        link.addEventListener('click', function(e) {
+          e.preventDefault();
+          tabLinks.forEach(l => l.classList.remove('active'));
+          tabPanes.forEach(p => p.classList.remove('active'));
+          this.classList.add('active');
+          document.querySelector(this.getAttribute('href')).classList.add('active');
+        });
+      });
+    });
     // Left sidebar toggle
     function toggleSidebar() {
       const sidebar = document.getElementById('sidebar');


### PR DESCRIPTION
## Summary
- Introduce Bootstrap-style nav tabs for Overview, Trends, and Activity Logs sections.
- Move Due Date Trend and Queues Due This Week charts into a dedicated Trends pane.
- Add JavaScript handler to switch tabs and placeholder pane for future Activity Log charts.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689918a90634832c9da33a9a2b87de78