### PR TITLE
Align chart dropdown checkboxes horizontally

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -125,6 +125,11 @@
       color: #007bff;
       font-weight: 500;
     }
+    #chartOptions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
     .right-panel-toggle {
       position: fixed;
       top: 50%;
@@ -870,10 +875,10 @@
           save();
         });
         const label = document.createElement('label');
+        label.style.display = 'inline-flex';
         label.appendChild(cb);
         label.appendChild(document.createTextNode(' ' + title));
         container.appendChild(label);
-        container.appendChild(document.createElement('br'));
         card.style.display = cb.checked ? '' : 'none';
       });
       function save() {


### PR DESCRIPTION
## Summary
- Arrange chart checkbox options in a flex container for horizontal layout with wrapping.
- Remove line breaks in `initChartDropdown` and display each label inline-flex so toggling continues to work.

## Testing
- `node test_dropdown.js` *(custom DOM simulation)*

------
https://chatgpt.com/codex/tasks/task_e_6899e1e6b074832ca6f45913463b1e36