### PR TITLE
Ensure toggle arrow sits above main content

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -32,6 +32,7 @@
       border: none;
       font-size: 18px;
       cursor: pointer;
+      z-index: 1000;
     }
     .sidebar h3 { font-size: 16px; margin-bottom: 20px; }
     .sidebar.collapsed h3,


### PR DESCRIPTION
## Summary
- prevent toggle arrow from being hidden beneath adjacent content by giving it a higher z-index

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3a8b3600832c975555447724c92b