### PR TITLE
Ensure log date filtering uses inclusive day range

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -526,15 +526,24 @@
 
     function normalizeDate(str) {
       if(!str) return '';
-      if(str.includes('/')) {
-        const [m, d, y] = str.split('/');
+      // Strip any time portion and parse the date in local time
+      const datePart = str.split(' ')[0];
+      const parsed = new Date(datePart);
+      if(!isNaN(parsed)) {
+        const year = parsed.getFullYear();
+        const month = String(parsed.getMonth() + 1).padStart(2, '0');
+        const day = String(parsed.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+      }
+      if(datePart.includes('/')) {
+        const [m, d, y] = datePart.split('/');
         return `${y.padStart(4,'0')}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`;
       }
-      if(str.includes('-')) {
-        const [y, m, d] = str.split('-');
+      if(datePart.includes('-')) {
+        const [y, m, d] = datePart.split('-');
         if(y.length === 4) return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`;
       }
-      return str;
+      return datePart;
     }
 
     function extractLogsFromData(data) {
@@ -871,7 +880,14 @@
           } else if (field === 'LogUser') {
             return d.Related && Array.isArray(d.Related.LOG) && d.Related.LOG.some(l => (l.User || '(Unknown)') === value);
           } else if (field === 'LogDate') {
-            return d.Related && Array.isArray(d.Related.LOG) && d.Related.LOG.some(l => normalizeDate(l.Date) === value);
+            const [y, m, dPart] = value.split('-').map(n => parseInt(n, 10));
+            const start = new Date(y, m - 1, dPart);
+            const end = new Date(y, m - 1, dPart + 1);
+            return d.Related && Array.isArray(d.Related.LOG) && d.Related.LOG.some(l => {
+              const ld = new Date(l.Date);
+              if (isNaN(ld)) return false;
+              return ld >= start && ld < end;
+            });
           } else if (field === 'LogTable') {
             return d.Related && Array.isArray(d.Related.LOG) && d.Related.LOG.some(l => (l.Table || '(Unknown)') === value);
           } else if (field === 'LogUserType') {


### PR DESCRIPTION
## Summary
- Normalize log dates by stripping time components and formatting as YYYY-MM-DD
- Filter logs by constructing a one-day range so date filters match entries on that exact day

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76318ae40832c9d43b7bde9c1bebc