### PR TITLE
Update modal assigned chart

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -1045,6 +1045,12 @@
       assignedToChart.data.datasets[0].data = aData.values;
       setChartColors(assignedToChart, 'AssignedTo');
       assignedToChart.update();
+      if (assignedToModalChart) {
+        assignedToModalChart.data.labels = aData.labels;
+        assignedToModalChart.data.datasets[0].data = aData.values;
+        setChartColors(assignedToModalChart, 'AssignedTo');
+        assignedToModalChart.update();
+      }
       let sData = statusData(data);
       statusChart.data.labels = sData.labels;
       statusChart.data.datasets[0].data = sData.values;


### PR DESCRIPTION
## Summary
- keep the AssignedTo modal chart synced when updating all charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77861fb78832c907aad50f2e65943