### PR TITLE
Add click filtering to AssignedTo modal chart

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -532,6 +532,13 @@
           }]
         },
         options: {
+          onClick: function(e, items) {
+            if(items.length) {
+              const label = this.data.labels[items[0].index];
+              toggleFilter('AssignedTo', label === "(Unassigned)" ? "" : label);
+            }
+            updateAllCharts();
+          },
           responsive: true,
           maintainAspectRatio: false,
           plugins: { legend: { display: false } },


### PR DESCRIPTION
## Summary
- Enable AssignedTo modal chart bars to toggle filters like the main chart

## Testing
- `npm test` *(fails: enoent missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77e208ae8832c8b2a3f087e1e19e1