### PR TITLE
Ensure AssignedTo modal chart applies filter highlights

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -549,6 +549,9 @@
         }
       });
 
+      assignedToModalChart.data.datasets[0].baseColor = 'rgba(0, 123, 255, 0.6)';
+      setChartColors(assignedToModalChart, 'AssignedTo');
+
       previousFocus = document.activeElement;
       modal.style.display = 'flex';
       modal.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary
- preserve default bar color in AssignedTo modal chart
- apply current filter highlights when opening AssignedTo modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a780279884832c912e5fb635359f89