### PR TITLE
Add reloadData helper and reset DataTable on new data

### DIFF
--- a/QueueManagerDashboardTemplate.html
+++ b/QueueManagerDashboardTemplate.html
@@ -578,7 +578,7 @@
       }
     }
     // ---- SAMPLE DATA (Replace with your actual JSON!) ----
-const rawData = [
+let rawData = [
  {"Admin":"","AssignedTo":"Ann Miranda","Call Log":"","ClaimID":"110702_76973_250721250724","Correspondence":"","DueDate":"8/18/2025","Event Date":"7/21/2025 - 7/24/2025","MRN":"11045645702","Parent Unit":"Home Health","Patient":"Leushtrng, Vinchrtent","Payor Name":"HPSM Care Advantage","Priority":"Low","QueueDate":"8/8/2025 4:59:30 PM","QueueID":"4E3BEEA3-AC1D-484F-A848-F1B2DDFCC592","RFNP":"","Related":{"LOG":[{"Date":"8/8/2025","Table":"Queue","Type":"New","User":"annmiranda@anxlife.com"}]},"SourceTable":"BilledAR","Status":"Billed","UB04":"","subRFNP":""},
 {"Admin":"","AssignedTo":"Ann Miranda","Call Log":"","ClaimID":"104604_76947_250730250730","Correspondence":"","DueDate":"8/18/2025","Event Date":"7/30/2025 - 7/30/2025","MRN":"1044565604","Parent Unit":"Home Health","Patient":"Cashstrtro, Yadthira","Payor Name":"HPSM Care Advantage","Priority":"Low","QueueDate":"8/8/2025 4:59:30 PM","QueueID":"B60BB9EA-A226-4944-892C-F9476C0D951F","RFNP":"","Related":{"LOG":[{"Date":"8/8/2025","Table":"Queue","Type":"New","User":"annmiranda@anxlife.com"}]},"SourceTable":"BilledAR","Status":"Billed","UB04":"","subRFNP":""},
 {"Admin":"","AssignedTo":"Johann Castaneda","Call Log":"","ClaimID":"400452_250625","Correspondence":"","DueDate":"8/22/2025","Event Date":"6/29/2025","MRN":"4004565452","Parent Unit":"Hospice","Patient":"T, Curghc B.","Payor Name":"SCFHP Room and Board","Priority":"Low","QueueDate":"8/8/2025 5:23:50 PM","QueueID":"FB4E556A-9407-C048-AC6E-E5A2E45E9DAE","RFNP":"","Related":{"LOG":[{"Date":"8/8/2025","Table":"Queue","Type":"Edit","User":"johanncastaneda@anxlife.com"},{"Date":"8/8/2025","Table":"Queue","Type":"Edit","User":"johanncastaneda@anxlife.com"},{"Date":"8/8/2025","Table":"Queue","Type":"Edit","User":"johanncastaneda@anxlife.com"},{"Date":"8/8/2025","Table":"Queue","Type":"Edit","User":"johanncastaneda@anxlife.com"},{"Date":"8/8/2025","Table":"Queue","Type":"New","User":"johanncastaneda@anxlife.com"}]},"SourceTable":"Claims","Status":"Sequential Billing","UB04":"","subRFNP":""}
@@ -965,12 +965,38 @@ const rawData = [
         `<button class="view-btn" onclick="openPanelRecord('${d.QueueID}','${d.SourceTable}','${d.MRN}','${d.ClaimID}')">View</button>` +
         (d["Call Log"] == "1" ? ` <button class="call-log-btn" onclick="openCallLog('${d.QueueID}','${d.SourceTable}','${d.MRN}','${d.ClaimID}')">Call Log</button>` : "")
       ]);
+
       if (table) {
-        table.clear().rows.add(rows).draw();
-      } else {
-        let html = rows.map(r => `<tr>${r.map(c => `<td>${c}</td>`).join('')}</tr>`).join('');
-        $("#tableBody").html(html);
+        table.clear().destroy();
       }
+
+      const html = rows.map(r => `<tr>${r.map(c => `<td>${c}</td>`).join('')}</tr>`).join('');
+      $("#tableBody").html(html);
+
+      table = $('#data-table table').DataTable({
+        scrollX: true,
+        scrollY: '400px',
+        paging: true,
+        ordering: true,
+        lengthMenu: [10, 25, 50, 100],
+        dom: 'Bfrtip',
+        buttons: [
+          { extend: 'excel', text: feather.icons["download"].toSvg() },
+          { extend: 'csv', text: feather.icons["file-text"].toSvg() },
+          { text: feather.icons["zoom-in"].toSvg(), action: function(){ zoomIn(); } },
+          { text: feather.icons["zoom-out"].toSvg(), action: function(){ zoomOut(); } }
+        ]
+      });
+
+      $('.dt-buttons #pageLength').remove();
+      const pageLength = $('<select id="pageLength"></select>');
+      table.settings().init().lengthMenu.forEach(len => {
+        pageLength.append(`<option value="${len}">${len}</option>`);
+      });
+      $('.dt-buttons').append(pageLength);
+      $('#pageLength').on('change', function() {
+        table.page.len(parseInt($(this).val())).draw();
+      });
     }
     function filterData() {
       let data = rawData;
@@ -1163,6 +1189,18 @@ const rawData = [
       adminChart.update();
       renderTable(data);
     }
+
+    function reloadData(jsonString) {
+      try {
+        rawData = JSON.parse(jsonString);
+      } catch (e) {
+        console.error("Invalid JSON passed to reloadData:", e);
+        return;
+      }
+      renderTable(rawData);
+      updateAllCharts();
+    }
+    window.reloadData = reloadData;
 
     function initChartDropdown() {
       const container = document.getElementById('chartOptions');
@@ -1747,32 +1785,6 @@ const rawData = [
         logsUserTypeHeatmapChart.userLabels = lhmData.users;
         logsUserTypeHeatmapChart.typeLabels = lhmData.types;
         setChartColors(logsUserTypeHeatmapChart, null, () => false);
-
-        renderTable(rawData);
-      table = $('#data-table table').DataTable({
-        scrollX: true,
-        scrollY: '400px',
-        paging: true,
-        ordering: true,
-        lengthMenu: [10, 25, 50, 100],
-        dom: 'Bfrtip',
-        buttons: [
-          { extend: 'excel', text: feather.icons["download"].toSvg() },
-          { extend: 'csv', text: feather.icons["file-text"].toSvg() },
-          { text: feather.icons["zoom-in"].toSvg(), action: function(){ zoomIn(); } },
-          { text: feather.icons["zoom-out"].toSvg(), action: function(){ zoomOut(); } }
-        ]
-      });
-
-      // Add page length selector next to the export buttons
-      const pageLength = $('<select id="pageLength"></select>');
-      table.settings().init().lengthMenu.forEach(len => {
-        pageLength.append(`<option value="${len}">${len}</option>`);
-      });
-      $('.dt-buttons').append(pageLength);
-        $('#pageLength').on('change', function() {
-          table.page.len(parseInt($(this).val())).draw();
-        });
 
       $('.chart-card, .chart-card canvas').on('dblclick', function(e) {
         const card = $(this).closest('.chart-card');


### PR DESCRIPTION
## Summary
- add reloadData to accept JSON from FileMaker and refresh table and charts
- reset DataTable instance before rendering new data to avoid stale state
- allow rawData to be reassigned when new data is loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4de308214832c892d57d012268ba2